### PR TITLE
Update braintreepayments URLs to paypal URLs

### DIFF
--- a/BraintreeVisaCheckout.podspec
+++ b/BraintreeVisaCheckout.podspec
@@ -7,10 +7,10 @@ Pod::Spec.new do |s|
 
                        This CocoaPod will help you accept Visa Checkout payments in your iOS app.
 
-                       Check out our development portal at https://developers.braintreepayments.com.
+                       Check out our development portal at https://developer.paypal.com/braintree/docs.
   DESC
   s.homepage         = "https://www.braintreepayments.com/how-braintree-works"
-  s.documentation_url = "https://developers.braintreepayments.com/guides/visa-checkout/overview"
+  s.documentation_url = "https://developer.paypal.com/braintree/docs/guides/secure-remote-commerce/overview"
   s.license          = "MIT"
   s.author           = { "Braintree" => "team-bt-sdk@paypal.com" }
   s.source           = { :git => "https://github.com/braintree/braintree-ios-visa-checkout.git", :tag => s.version.to_s }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,14 +12,14 @@ The integration tests require a full Braintree stack running on localhost.
 
 ## Environmental Assumptions
 
-* See [Requirements](https://developers.braintreepayments.com/guides/client-sdk/setup/ios/v4#requirements)
+* See [Requirements](https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ios/v5#requirements)
 * iPhone and iPad of all sizes and resolutions and the Simulator
 * CocoaPods
 * `BT` namespace is reserved for Braintree
 * Host app does not integrate the [PayPal iOS SDK](https://github.com/paypal/paypal-ios-sdk)
 * Host app does not integrate with the Kount SDK
 * Host app does not integrate with [card.io](https://www.card.io/)
-* Host app has a secure, authenticated server with a [Braintree server-side integration](https://developers.braintreepayments.com/ios/start/hello-server)
+* Host app has a secure, authenticated server with a [Braintree server-side integration](https://developer.paypal.com/braintree/docs/start/hello-server)
 
 ## Committing
 


### PR DESCRIPTION
### Summary of changes

- Update URLs from `developers.braintreepayments.com` to the correct `developer.paypal.com` URLs

### Checklist

- ~[ ] Added a changelog entry~ I do not think we need a changelog for this since no behavior changed we are just fixing links, but can add an entry if someone feels strongly about it

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @Epreuve @jaxdesmarais 